### PR TITLE
Use Microsoft site for Azure Cosmos DB Data Migration Tool.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Prior to starting these labs, you must have the following operating system and s
 | --- | --- |
 | .NET Core 2.1 (or greater) SDK | [/download.microsoft.com/dotnet-sdk-2.1](https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe)
 | Visual Studio Code | [/code.visualstudio.com/download](https://go.microsoft.com/fwlink/?Linkid=852157) |
-| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](../files/cosmosdt.zip) |
+| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](https://aka.ms/AzureDocumentDBDataMigrationTool) |
 
 # Labs
 

--- a/technical_deep_dive/02-creating_multi_partition_solution.md
+++ b/technical_deep_dive/02-creating_multi_partition_solution.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | .NET Core 2.1 (or greater) SDK | [/download.microsoft.com/dotnet-sdk-2.1](https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe)
 | Visual Studio Code | [/code.visualstudio.com/download](https://go.microsoft.com/fwlink/?Linkid=852157) |
-| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](../files/cosmosdt.zip) |
+| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](https://aka.ms/AzureDocumentDBDataMigrationTool) |
 
 ## Setup
 

--- a/technical_deep_dive/04-querying_the_database_using_sql.md
+++ b/technical_deep_dive/04-querying_the_database_using_sql.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | .NET Core 2.1 (or greater) SDK | [/download.microsoft.com/dotnet-sdk-2.1](https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe)
 | Visual Studio Code | [/code.visualstudio.com/download](https://go.microsoft.com/fwlink/?Linkid=852157) |
-| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](../files/cosmosdt.zip) |
+| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](https://aka.ms/AzureDocumentDBDataMigrationTool) |
 
 ## Setup
 

--- a/technical_deep_dive/05-authoring_stored_procedures.md
+++ b/technical_deep_dive/05-authoring_stored_procedures.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | .NET Core 2.1 (or greater) SDK | [/download.microsoft.com/dotnet-sdk-2.1](https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe)
 | Visual Studio Code | [/code.visualstudio.com/download](https://go.microsoft.com/fwlink/?Linkid=852157) |
-| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](../files/cosmosdt.zip) |
+| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](https://aka.ms/AzureDocumentDBDataMigrationTool) |
 
 ## Setup
 

--- a/technical_deep_dive/06-troubleshooting_failed_requests.md
+++ b/technical_deep_dive/06-troubleshooting_failed_requests.md
@@ -6,7 +6,7 @@
 | --- | --- |
 | .NET Core 2.1 (or greater) SDK | [/download.microsoft.com/dotnet-sdk-2.1](https://download.microsoft.com/download/E/2/6/E266C257-F7AF-4E79-8EA2-DF26031C84E2/dotnet-sdk-2.1.103-win-gs-x64.exe)
 | Visual Studio Code | [/code.visualstudio.com/download](https://go.microsoft.com/fwlink/?Linkid=852157) |
-| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](../files/cosmosdt.zip) |
+| Azure Cosmos DB Data Migration Tool | [/cosmosdb-data-migration-tool](https://aka.ms/AzureDocumentDBDataMigrationTool) |
 
 ## Setup
 


### PR DESCRIPTION
Use https://aka.ms/AzureDocumentDBDataMigrationTool instead of zip file in the repository.
It seems that the link to the Azure Document DB Data Migration Tool is broken in https://seesharprun.github.io/cosmos-workshop/ as the relative path points to one folder back which is not true for that page. The proposed fix modifies the links and points them to an aka.ms shortlink which redirects to the official Microsoft download page. We could also remove the zip file from the repository.