### PR TITLE
Add instructions on how to download json files.

### DIFF
--- a/technical_deep_dive/04-querying_the_database_using_sql.md
+++ b/technical_deep_dive/04-querying_the_database_using_sql.md
@@ -16,7 +16,7 @@ Before starting any lab in this workshop, you will need to create the various Az
 
 *A JSON file has been provided that will contain a collection 50,000 students. You will use this file later to import documents into your collection.*
 
-1. Download the [students.json](../files/students.json) file and save it to your local machine.
+1. Download the students.json file to your local machine by right clicking on [this link](../files/students.json) and selecting 'save target as' or 'save link as' depending on your browser.
 
 ### Create Azure Cosmos DB Assets
 

--- a/technical_deep_dive/06-troubleshooting_failed_requests.md
+++ b/technical_deep_dive/06-troubleshooting_failed_requests.md
@@ -16,7 +16,7 @@ Before starting any lab in this workshop, you will need to create the various Az
 
 *A JSON file has been provided that will contain a collection 50,000 students. You will use this file later to import documents into your collection.*
 
-1. Download the [transactions.json](../files/transactions.json) file and save it to your local machine.
+1. Download the transactions.json file to your local machine by right clicking on [this link](../files/transactions.json) and selecting 'save target as' or 'save link as' depending on your browser.
 
 ### Create Azure Cosmos DB Assets
 


### PR DESCRIPTION
Add instructions to right click on the json files and save the file instead of clicking on the link. An alternative is to add <a href='pathtofile' download>filename</a> but I am not sure if it works on all browsers.